### PR TITLE
Fix null campaign structure error

### DIFF
--- a/templates/admin/post_text/index.html.twig
+++ b/templates/admin/post_text/index.html.twig
@@ -62,11 +62,15 @@
             <tr>
                 <td>{{ post_text.content }}</td>
                 <td>
-                    {{ post_text.campaingStructure.campaign.name }}<br>
-                    {{ post_text.campaingStructure.campaign.client.name }}
+                    {% if post_text.campaingStructure %}
+                        {{ post_text.campaingStructure.campaign.name }}<br>
+                        {{ post_text.campaingStructure.campaign.client.name }}
+                    {% else %}
+                        -
+                    {% endif %}
                 </td>
                 <td>
-                    {{ post_text.campaingStructure.title }}
+                    {{ post_text.campaingStructure ? post_text.campaingStructure.title : '-' }}
                 </td>
                 <td>
                     <a href="{{ path('app_admin_post_text_edit', {'id': post_text.id}) }}" class="btn btn-primary float-end" >Editar</a>


### PR DESCRIPTION
## Summary
- avoid error when PostText has no CampaingStructure on admin listing

## Testing
- `composer install -n`
- `php bin/console lint:twig templates/admin/post_text/index.html.twig`


------
https://chatgpt.com/codex/tasks/task_e_6887e6356ebc832c8f79175e2522aaaf