### PR TITLE
Fix history offset warning

### DIFF
--- a/src/Controller/Admin/CampaignController.php
+++ b/src/Controller/Admin/CampaignController.php
@@ -175,8 +175,8 @@ class CampaignController extends AbstractController
         $history = $postService->getHistoryPost($campaign->getClient());
 
         $dataHistory = [];
-        if ($history['success'] == true){
-            $dataHistory = $history['data'];
+        if (is_array($history) && ($history['success'] ?? false) === true) {
+            $dataHistory = $history['data'] ?? [];
         }
 
         return $this->render('admin/campaign/prompt.html.twig', [


### PR DESCRIPTION
## Summary
- avoid array access on boolean in CampaignController

## Testing
- `composer validate --no-check-publish`
- `php -l src/Controller/Admin/CampaignController.php`
- `php -l src/Service/PostService.php`


------
https://chatgpt.com/codex/tasks/task_e_6887e6e63198832c993407eeee819912