### PR TITLE
Cria avisos quando token do Facebook está indefinido

### DIFF
--- a/src/Service/PostService.php
+++ b/src/Service/PostService.php
@@ -54,6 +54,9 @@ class PostService
 
         $token = $this->security->getUser()->getFacebookAccessToken();
         if ($token == null || $token == ""){
+            $session = new Session();
+            $flashes = $session->getFlashBag();
+            $flashes->add('error', 'Token do Facebook não definido');
             return false;
         }
 
@@ -136,7 +139,9 @@ class PostService
 
         $token = $this->security->getUser()->getFacebookAccessToken();
         if ($token == null || $token == ""){
-            echo 'sem getFacebookAccessToken';
+            $session = new Session();
+            $flashes = $session->getFlashBag();
+            $flashes->add('error', 'Token do Facebook não definido');
             return false;
         }
 
@@ -188,6 +193,8 @@ class PostService
 
         $token = $this->security->getUser()->getFacebookAccessToken();
         if ($token == null || $token == ""){
+            $session = new Session();
+            $session->getFlashBag()->add('error', 'Token do Facebook não definido');
             return false;
         }
 
@@ -206,6 +213,8 @@ class PostService
 
         $token = $this->security->getUser()->getFacebookAccessToken();
         if ($token == null || $token == ""){
+            $session = new Session();
+            $session->getFlashBag()->add('error', 'Token do Facebook não definido');
             return false;
         }
 


### PR DESCRIPTION
## Summary
- exibe mensagem de erro quando o token do Facebook não está configurado

## Testing
- `php -l src/Service/PostService.php`


------
https://chatgpt.com/codex/tasks/task_e_6887e8b3f07c832cb08aae7e49046ac1